### PR TITLE
docs: fix case in folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install:
 -------
 ```ruby
 git clone git://github.com/hectorperez/agreelist.git
-cd AgreeList
+cd agreelist
 bundle install
 cp config/database.yml.example config/database.yml
 rake db:create


### PR DESCRIPTION
minor change: change folder name to lowercase to make it work in unix-based systems, that are case sensitive.