### PR TITLE
resque is not used now

### DIFF
--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,1 +1,0 @@
-require 'resque/tasks'


### PR DESCRIPTION
When I tried to use rake, I got an error: `LoadError: cannot load such file -- resque/tasks`